### PR TITLE
Add summary ConsoleReporter

### DIFF
--- a/src/lib/console-reporter.spec.ts
+++ b/src/lib/console-reporter.spec.ts
@@ -1,0 +1,70 @@
+import * as path from 'path'
+import { FeatureRunner } from './runner'
+import { ConsoleReporter, Config } from './console-reporter'
+import { storageStepRunners } from '../steps/storage'
+
+const createRunner = (config?: Partial<Config>) => {
+	const mockConsole = {
+		log: jest.fn<void, any>(),
+		error: jest.fn<void, any>(),
+	}
+	const runner = new FeatureRunner<any>(
+		{},
+		{
+			reporters: [
+				new ConsoleReporter({
+					...config,
+					console: mockConsole,
+				}),
+			],
+			dir: path.join(process.cwd(), 'test', 'storage'),
+			retry: false,
+			store: {
+				foo: 'bar',
+				bar: {
+					baz: 'foo',
+					num: 42,
+					b: true,
+				},
+			},
+		},
+	)
+	return {
+		runner,
+		mockConsole,
+	}
+}
+
+const stripColors = (s: string) => s.replace(/\u001b\[[0-9;]+m/g, '')
+
+describe('Console Reporter', () => {
+	it('should print a summary if printSummary=true', async () => {
+		const { runner, mockConsole } = createRunner({ printSummary: true })
+
+		const { success } = await runner.addStepRunners(storageStepRunners()).run()
+		expect(success).toEqual(true)
+
+		const logs = mockConsole.log.mock.calls
+			.map(args => args.join(' '))
+			.join('\n')
+
+		expect(stripColors(logs)).toMatch(
+			/Feature Summary:   0 failed, 0 skipped, 3 passed, 3 total/,
+		)
+		expect(stripColors(logs)).toMatch(
+			/Scenario Summary:  0 failed, 0 skipped, 10 passed, 10 total/,
+		)
+	})
+	it('should not print a summary if printSummary=false', async () => {
+		const { runner, mockConsole } = createRunner()
+
+		const { success } = await runner.addStepRunners(storageStepRunners()).run()
+		expect(success).toEqual(true)
+
+		const logs = mockConsole.log.mock.calls
+			.map(args => args.join(' '))
+			.join('\n')
+
+		expect(logs).not.toContain('Feature Summary:')
+	})
+})

--- a/src/lib/console-reporter.ts
+++ b/src/lib/console-reporter.ts
@@ -10,17 +10,32 @@ import * as chalk from 'chalk'
 import * as Chai from 'chai'
 import { messages as cucumber } from 'cucumber-messages'
 
-type Config = { printResults: boolean; printProgress: boolean, printProgressTimestamps?: boolean }
+type Config = {
+	printResults: boolean
+	printProgress: boolean
+	printProgressTimestamps?: boolean
+}
 
 export class ConsoleReporter implements Reporter {
 	private readonly config: Config
 	private lastProgress?: number
 
-	constructor(config: Config = { printResults: false, printProgress: false, printProgressTimestamps: false }) {
+	constructor(
+		config: Config = {
+			printResults: false,
+			printProgress: false,
+			printProgressTimestamps: false,
+		},
+	) {
 		this.config = config
 	}
 
 	async report(result: RunResult) {
+		console.log('')
+		console.log('-----------------------------')
+		console.log('Feature Test Detailed Results')
+		console.log('-----------------------------')
+		console.log('')
 		result.featureResults.forEach(featureResult => {
 			reportFeature(featureResult)
 			featureResult.scenarioResults.forEach(scenarioResult => {
@@ -29,6 +44,21 @@ export class ConsoleReporter implements Reporter {
 					reportStep(stepResult, this.config)
 				})
 			})
+		})
+		console.log('')
+		console.log('--------------------------------')
+		console.log('Feature Test Summary of Failures')
+		console.log('--------------------------------')
+		console.log('')
+		result.featureResults.forEach(featureResult => {
+			if (!featureResult.feature.skip && !featureResult.success) {
+				reportFeature(featureResult)
+				featureResult.scenarioResults.forEach(scenarioResult => {
+					if (!scenarioResult.skipped && !scenarioResult.success) {
+						reportScenario(scenarioResult)
+					}
+				})
+			}
 		})
 		reportRunResult(result.success, result.runTime)
 		if (result.error) {
@@ -48,8 +78,7 @@ export class ConsoleReporter implements Reporter {
 		if (this.config.printProgressTimestamps) {
 			i.push(chalk.grey(`[${new Date().toISOString()}]`))
 		}
-		i.push(chalk.magenta(' ℹ '),
-			chalk.cyan(type))
+		i.push(chalk.magenta(' ℹ '), chalk.cyan(type))
 		if (info) {
 			i.push(chalk.grey(info))
 		}
@@ -72,11 +101,10 @@ const reportFeature = (result: FeatureResult) => {
 			chalk.magenta('↷ (skipped)'),
 		)
 	} else {
-		console.log('', chalk.yellow.bold(`${result.feature.name}`))
+		console.log('', 'Feature: ', chalk.yellow.bold(`${result.feature.name}`))
 		console.log('')
 
-<<<<<<< HEAD
-		i.push(result.success ? chalk.green(' 💯') : chalk.red.bold(' ❌'))
+		i.push(result.success ? ' 💚' : ' ❌')
 		if (result.runTime) {
 			i.push(chalk.blue(`⏱ ${result.runTime}ms`))
 		}
@@ -86,27 +114,14 @@ const reportFeature = (result: FeatureResult) => {
 	}
 	console.log(...i)
 }
-=======
-  if (result.feature.skip) {
-    i.push(chalk.magenta(' ↷ '), chalk.magenta('(skipped)'));
-  } else {
-    i.push(result.success ? ' 💚' : ' ❌');
-    if (result.runTime) {
-      i.push(chalk.blue(`⏱ ${result.runTime}ms`));
-    }
-  }
-  if (result.feature.tags.length) {
-    i.push(chalk.magenta(result.feature.tags.map(({ name }) => name)));
-  }
-  console.log(...i);
-};
->>>>>>> f750488... fix: better icons for red/green visual scanning
 
 const reportScenario = (result: ScenarioResult) => {
 	console.log('')
-	const type = result.scenario instanceof cucumber.GherkinDocument.Feature.Background ?
-		'Background' : 'Scenario'
-	const i = [chalk.gray(type)]
+	const type =
+		result.scenario instanceof cucumber.GherkinDocument.Feature.Background
+			? 'Background'
+			: 'Scenario'
+	const i = [chalk.gray(type) + ':']
 	if (result.skipped) {
 		i.push(chalk.magenta(' ↷ '), chalk.magenta('(skipped)'))
 		if (result.scenario.name) {

--- a/src/lib/console-reporter.ts
+++ b/src/lib/console-reporter.ts
@@ -75,6 +75,7 @@ const reportFeature = (result: FeatureResult) => {
 		console.log('', chalk.yellow.bold(`${result.feature.name}`))
 		console.log('')
 
+<<<<<<< HEAD
 		i.push(result.success ? chalk.green(' 💯') : chalk.red.bold(' ❌'))
 		if (result.runTime) {
 			i.push(chalk.blue(`⏱ ${result.runTime}ms`))
@@ -85,6 +86,21 @@ const reportFeature = (result: FeatureResult) => {
 	}
 	console.log(...i)
 }
+=======
+  if (result.feature.skip) {
+    i.push(chalk.magenta(' ↷ '), chalk.magenta('(skipped)'));
+  } else {
+    i.push(result.success ? ' 💚' : ' ❌');
+    if (result.runTime) {
+      i.push(chalk.blue(`⏱ ${result.runTime}ms`));
+    }
+  }
+  if (result.feature.tags.length) {
+    i.push(chalk.magenta(result.feature.tags.map(({ name }) => name)));
+  }
+  console.log(...i);
+};
+>>>>>>> f750488... fix: better icons for red/green visual scanning
 
 const reportScenario = (result: ScenarioResult) => {
 	console.log('')
@@ -114,7 +130,7 @@ const reportScenario = (result: ScenarioResult) => {
 const reportRunResult = (success: boolean, runTime?: number) => {
 	console.log('')
 	const i = [
-		success ? chalk.green(' 💯 ALL PASS ') : chalk.red.bold(' 💀 FAIL 👎 '),
+		success ? chalk.green(' 💚 ALL PASS 👍 ') : chalk.red.bold(' ❌ FAIL 👎 '),
 	]
 	if (runTime) {
 		i.push(chalk.blue(`⏱ ${runTime}ms`))


### PR DESCRIPTION
This integrates the changes from nRFCloud/bdd-feature-runner-aws#8 with some smaller modifications:

- summary output is behind a configuration flag: `printSummary: true`
- prettier, colorized summary
- refactored the summary method to separate statistics and printing business
- reverts the icon change. We keep using :100: for all tests passed.